### PR TITLE
save_all: show saved file path

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -236,7 +236,7 @@ remove_old_backups() {
 }
 
 save_all() {
-	local resurrect_file_path="$(resurrect_file_path)"
+	resurrect_file_path="$(resurrect_file_path)"
 	local last_resurrect_file="$(last_resurrect_file)"
 	mkdir -p "$(resurrect_dir)"
 	fetch_and_dump_grouped_sessions > "$resurrect_file_path"
@@ -271,7 +271,7 @@ main() {
 		save_all
 		if show_output; then
 			stop_spinner
-			display_message "Tmux environment saved!"
+			display_message "Tmux environment saved in ${resurrect_file_path}!"
 		fi
 	fi
 }


### PR DESCRIPTION
Elevated the saved session location to a global variable to enable showing the location of the file when the save completes.  For reasons unkown, without doing this, the save operation was failing and no session was actually being written.  So in addition to being informative, this seems to correct some mysterious bug.